### PR TITLE
pod_killer: fix nil pointer dereference for non-csi volumes

### DIFF
--- a/pod_killer.go
+++ b/pod_killer.go
@@ -66,7 +66,7 @@ func (podKiller *PodKiller) Run(monitoringInterval *time.Duration) {
 func (podKiller *PodKiller) filterProvisionerPVs(pvs *v1.PersistentVolumeList) map[string]v1.PersistentVolume {
 	provisionerPVs := make(map[string]v1.PersistentVolume)
 	for _, pv := range pvs.Items {
-		if pv.Spec.CSI.Driver == podKiller.CSIProvisionerName {
+    if pv.Spec.CSI != nil &&  pv.Spec.CSI.Driver == podKiller.CSIProvisionerName {
 			provisionerPVs[pv.Name] = pv
 		}
 	}


### PR DESCRIPTION
In case a PV does not have `spec.CSI` defined (e.g. a hostpath volume),
it should just be ignored and not cause a nil pointer dereference.

fixes: https://github.com/quobyte/quobyte-csi/issues/36