### PR TITLE
Simplify and fix pod killer delete queuing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pod_killer

--- a/csi_mounts_monitor.go
+++ b/csi_mounts_monitor.go
@@ -232,13 +232,10 @@ func getStalePVNames(podUid string) []string {
 		quobyteCsiVolumePath := fmt.Sprintf(KUBELET_POD_CSI_PVC_MOUNT, podUid, csiPVName)
 		if _, err = unix.Getxattr(quobyteCsiVolumePath, QUOBYTE_CLIENT_X_ATTR, xattr_buf); err != nil {
 			klog.V(2).Infof("Encountered error %d executing stat on %s", err.(syscall.Errno), quobyteCsiVolumePath)
-			if err.(syscall.Errno) == unix.ENOTCONN || err.(syscall.Errno) == unix.ENOENT {
+			if err.(syscall.Errno) == unix.ENOTCONN {
 				stalePvNames = append(stalePvNames, csiPVName)
 			}
 		}
-	}
-	if len(stalePvNames) > 0 {
-		klog.Infof("PVs %v are stale in the path %s", stalePvNames, podVolumesPath)
 	}
 	return stalePvNames
 }

--- a/main.go
+++ b/main.go
@@ -33,10 +33,10 @@ var (
 	csiProvisionerName = flag.String("driver_name", "", "CSI provisioner name (must match the CSI provisioner name)")
 
 	// For monitoring stale pod mounts on node
-	monitoringInterval = flag.Duration("monitoring_interval", 5*time.Second, "monitoring interval")
-	nodeName           = flag.String("node_name", "", "K8S node name")
-	serviceUrl         = flag.String("service_url", "", "Pod killer controller service URL")
-	parallelKills      = flag.Int("parallel_kills", 10, "Kill 'n' pods with stale mount points")
+	monitoringInterval     = flag.Duration("monitoring_interval", 5*time.Second, "monitoring interval")
+	nodeName               = flag.String("node_name", "", "K8S node name")
+	serviceUrl             = flag.String("service_url", "", "Pod killer controller service URL")
+	parallelKills          = flag.Int("parallel_kills", 10, "Kill 'n' pods with stale mount points")
 )
 
 func main() {
@@ -96,12 +96,13 @@ func main() {
 		klog.Infof("Start monitoring of stale pod mounts every %s on node %s and use %s to resolve pod name/namespace",
 			*monitoringInterval, *nodeName, *serviceUrl)
 		monitor := &CsiMountMonitor{
-			clientSet:          clientset,
-			csiDriverName:      *csiProvisionerName,
-			nodeName:           *nodeName,
-			monitoringInterval: *monitoringInterval,
-			controller_url:     *serviceUrl,
-			parallelKills:      *parallelKills,
+			clientSet:              clientset,
+			csiDriverName:          *csiProvisionerName,
+			nodeName:               *nodeName,
+			monitoringInterval:     *monitoringInterval,
+			controller_url:         *serviceUrl,
+			parallelKills:          *parallelKills,
+			podDeletionQueue:       NewPodDeletionQueue(),
 		}
 		monitor.Run()
 	} else {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	monitoringInterval     = flag.Duration("monitoring_interval", 5*time.Second, "monitoring interval")
 	nodeName               = flag.String("node_name", "", "K8S node name")
 	serviceUrl             = flag.String("service_url", "", "Pod killer controller service URL")
+	podUidResolveBatchSize = flag.Int("pod_lookup_batch_size", 10, "Batch size for pod uid resolution")
 	parallelKills          = flag.Int("parallel_kills", 10, "Kill 'n' pods with stale mount points")
 )
 
@@ -102,6 +103,7 @@ func main() {
 			monitoringInterval:     *monitoringInterval,
 			controller_url:         *serviceUrl,
 			parallelKills:          *parallelKills,
+			podUidResolveBatchSize: *podUidResolveBatchSize,
 			podDeletionQueue:       NewPodDeletionQueue(),
 		}
 		monitor.Run()

--- a/types.go
+++ b/types.go
@@ -20,3 +20,8 @@ type ResolvedPod struct {
 type ResolvePodsResponse struct {
 	Pods []ResolvedPod `json:"pods"`
 }
+
+type ResolvedPodWithStaleMounts struct {
+	ResolvedPod ResolvedPod
+	StaleMount  StaleMount
+}


### PR DESCRIPTION
* Fixed a caching bug that was not triggering pod delete
* Abstracted delete queueing and locking
* Improved batching of lookup requests
* Improved mount monitoring (ENOTCONN is considered staleness to avoid unnecessary lookups)
* Added more logs to identify issues and provide more information
